### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -1,4 +1,6 @@
 name: CI Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/3](https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/3)

The correct and most secure fix is to add a `permissions` block that grants only the minimum permissions needed by the workflow. Since this workflow merely checks out code and runs tests, the only required permission is likely `contents: read`. Place the following at the top level of the workflow file (at the same indentation as `name`, `on`, and `jobs`) so that it applies to the entire workflow and all jobs. No new methods, imports, or additional configuration are required. 

Insert the following block between the `name` and `on` keys:

```yaml
permissions:
  contents: read
```

This change ensures that the GITHUB_TOKEN scoped for the workflow only has read access to repository contents, reducing risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
