### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/8](https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/8)

To fix the problem, we should add an explicit `permissions` block to the workflow to restrict the permissions of the `GITHUB_TOKEN` to only what is needed. Since the workflow does not appear to make any write operations to the repository (such as pushing changes or managing issues), a minimal starting point is `contents: read`. We should add this block at the workflow level (before `jobs:`), as per the recommendation, which will apply to all jobs unless they override these permissions. No imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
