### PR TITLE
Fix for Missing call to superclass `__init__` during object initialization

### DIFF
--- a/src/mechanics_dsl/integrations/unity.py
+++ b/src/mechanics_dsl/integrations/unity.py
@@ -33,6 +33,7 @@ class UnityGenerator(CodeGenerator if CodeGenerator != object else object):
         return ".cs"
     
     def __init__(self, compiler=None):
+        super().__init__()
         self.compiler = compiler
         if compiler:
             self.system_name = getattr(compiler, 'system_name', 'Physics')


### PR DESCRIPTION
To fix the problem, ensure that `UnityGenerator.__init__` calls the base class `__init__` so any required initialization in `CodeGenerator` is executed. Because the superclass is conditionally `CodeGenerator` or `object`, using `super().__init__()` is safe and will just invoke `object.__init__` in the fallback case, which is harmless.

The best minimally invasive change is to add a `super().__init__()` call at the top of `UnityGenerator.__init__`. We should not alter the existing arguments or behavior of `UnityGenerator.__init__`; instead, we call `super().__init__()` with no arguments, assuming the base class has a no-arg or fully defaulted `__init__`, which is the most compatible change given we cannot inspect the rest of the code. Concretely, in `src/mechanics_dsl/integrations/unity.py`, modify the `__init__` method of `UnityGenerator` to insert `super().__init__()` as the first statement inside the method body, before any assignments to `self.compiler` or related attributes. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._