### PR TITLE
Potential fix for code scanning alert no. 711: Illegal raise

### DIFF
--- a/src/mechanics_dsl/error_handling.py
+++ b/src/mechanics_dsl/error_handling.py
@@ -269,7 +269,12 @@ def retry(
                     else:
                         logger.error(f"All {max_attempts} attempts failed for {func.__name__}")
 
-            raise last_exception
+            if last_exception is not None:
+                raise last_exception
+            raise RuntimeError(
+                f"Retry wrapper for {func.__name__} failed without capturing an exception; "
+                f"check max_attempts ({max_attempts}) and exceptions configuration."
+            )
 
         return wrapper
 


### PR DESCRIPTION
Potential fix for [https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/711](https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/711)

In general, to fix this issue we must ensure that the object in the `raise` statement is always a valid exception instance or class. Since `last_exception` is potentially `None`, the safest approach is to check whether it is set before raising it. If it is `None`, we should instead raise a new, explicit exception that clearly describes the internal error, rather than attempting to re-raise `None`.

The best minimal-impact fix is to replace the bare `raise last_exception` with a conditional: if `last_exception` is not `None`, raise it as before; otherwise, raise a generic `RuntimeError` (or similar) explaining that no exception was captured during retries. This preserves existing behavior in all cases where an exception actually occurred, and only changes the behavior for edge cases where the logic would have failed with a `TypeError`. The change is localized to the `wrapper` function in the `retry` decorator (around line 272 in `src/mechanics_dsl/error_handling.py`) and does not require any new imports or additional helper methods.

Concretely:
- In `src/mechanics_dsl/error_handling.py`, locate the `raise last_exception` line in the `wrapper` inside the `retry` decorator.
- Replace it with an `if last_exception is not None:` branch that raises it, and an `else:` branch that raises an appropriate fallback exception like `RuntimeError` with a descriptive message.
- No new imports or global definitions are needed since `RuntimeError` is a built-in exception class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
