### PR TITLE
Potential fix for code scanning alert no. 757: Unused import

### DIFF
--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -6,7 +6,7 @@ Run with:
 """
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from io import StringIO
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/757](https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/757)

In general, unused-import issues are fixed by either removing the unused symbol from the import statement or starting to use it meaningfully in the code. To avoid changing behavior, the best approach here is to simply remove `MagicMock` from the import, leaving the still-used `patch` intact.

Specifically, in `tests/test_repl.py` at the top of the file, adjust line 9 from importing both `patch` and `MagicMock` to importing only `patch`. No other changes are needed, as there is no usage of `MagicMock` in the shown code. This keeps the tests functioning as before while removing the unnecessary dependency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
