### PR TITLE
Potential fix for code scanning alert no. 382: Pythagorean calculation with sub-optimal numerics

### DIFF
--- a/src/mechanics_dsl/domains/kinematics/motion_2d.py
+++ b/src/mechanics_dsl/domains/kinematics/motion_2d.py
@@ -101,7 +101,7 @@ class Vector2D:
     @property
     def magnitude(self) -> float:
         """Get magnitude (length) of vector."""
-        return math.sqrt(self.x**2 + self.y**2)
+        return math.hypot(self.x, self.y)
 
     @property
     def magnitude_squared(self) -> float:


### PR DESCRIPTION
Potential fix for [https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/382](https://github.com/MechanicsDSL/mechanicsdsl/security/code-scanning/382)

In general, to fix this kind of issue you replace the manual Pythagorean computation `sqrt(a**2 + b**2)` with the numerically stable `math.hypot(a, b)`. `math.hypot` is designed to avoid unnecessary overflow and underflow by scaling the arguments internally.

For this specific code, the best fix is to change the `magnitude` property in `Vector2D` from:

```python
return math.sqrt(self.x**2 + self.y**2)
```

to:

```python
return math.hypot(self.x, self.y)
```

This keeps the public behavior (returning the Euclidean norm) while improving numerical robustness. No new imports are required because `math` is already imported at the top of `motion_2d.py`. No other lines or methods need to be changed.

The change is confined to `src/mechanics_dsl/domains/kinematics/motion_2d.py`, within the `Vector2D.magnitude` property at line 104.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
